### PR TITLE
Added option to ignore network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ $ collect -l -u=http://localhost:8080
 ```
 
 ## Command-Line flags
-| Flag        | Default                        | Usage                                     |
-| ----------- | -------------------------------| ----------------------------------------- |
-| -u          |                                | url from which profiles will be collected.|
-| -p          | allocs,heap,goroutine,profile  | profiles to collect.                      |
-| -l          | false                          | collect profiles in endless loop          |
-| -i          | 60s                            | interval between collecting. use with -l  |
-| -d          | ./                             | directory to put the pprof files in.      |
+| Flag        | Default                        | Usage                                      |
+| ----------- | -------------------------------| -------------------------------------------|
+| -u          |                                | url from which profiles will be collected. |
+| -p          | allocs,heap,goroutine,profile  | profiles to collect.                       |
+| -l          | false                          | collect profiles in endless loop           |
+| -i          | 60s                            | interval between collecting. use with -l   |
+| -d          | ./                             | directory to put the pprof files in.       |
+| -k          | false                          | keep going collect if some requests failed.|

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/tommsawyer/collect
 go 1.16
 
 require (
-	github.com/jessevdk/go-flags v1.5.0 // indirect
+	github.com/jessevdk/go-flags v1.5.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/profiles/profiles_test.go
+++ b/profiles/profiles_test.go
@@ -39,7 +39,7 @@ func TestCollectProfiles(t *testing.T) {
 
 	t.Run("collect one profile", func(t *testing.T) {
 		testLog.LogTo(t)
-		profiles, err := Collect(context.Background(), srv.URL, []string{"allocs"})
+		profiles, err := Collect(context.Background(), srv.URL, []string{"allocs"}, false)
 		if err != nil {
 			t.Errorf("error should be nil, but got %v", err)
 		}
@@ -51,7 +51,7 @@ func TestCollectProfiles(t *testing.T) {
 
 	t.Run("collect many profiles", func(t *testing.T) {
 		testLog.LogTo(t)
-		profiles, err := Collect(context.Background(), srv.URL, []string{"allocs", "profile"})
+		profiles, err := Collect(context.Background(), srv.URL, []string{"allocs", "profile"}, false)
 		if err != nil {
 			t.Errorf("error should be nil, but got %v", err)
 		}
@@ -66,7 +66,7 @@ func TestCollectProfiles(t *testing.T) {
 
 	t.Run("collect profile with query parameters", func(t *testing.T) {
 		testLog.LogTo(t)
-		profiles, err := Collect(context.Background(), srv.URL, []string{"trace?seconds=5"})
+		profiles, err := Collect(context.Background(), srv.URL, []string{"trace?seconds=5"}, false)
 		if err != nil {
 			t.Errorf("error should be nil, but got %v", err)
 		}
@@ -77,16 +77,23 @@ func TestCollectProfiles(t *testing.T) {
 	})
 
 	t.Run("returns error when cannot build url", func(t *testing.T) {
-		_, err := Collect(context.Background(), "http://wrong.wrong\n", []string{"allocs"})
+		_, err := Collect(context.Background(), "http://wrong.wrong\n", []string{"allocs"}, false)
 		if err == nil || !strings.Contains(err.Error(), "cannot build url:") {
 			t.Error("should return error when wrong url provided")
 		}
 	})
 
 	t.Run("returns error when server is unreachable", func(t *testing.T) {
-		_, err := Collect(context.Background(), "http://wrong.wrong", []string{"allocs"})
+		_, err := Collect(context.Background(), "http://wrong.wrong", []string{"allocs"}, false)
 		if err == nil || !strings.Contains(err.Error(), "cannot collect allocs:") {
 			t.Error("should return error when server is unreachable")
+		}
+	})
+
+	t.Run("returns no error when server is unreachable and ignore network errors is true", func(t *testing.T) {
+		_, err := Collect(context.Background(), "http://wrong.wrong", []string{"allocs"}, true)
+		if err != nil {
+			t.Errorf("error should be nil, but got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
For example, in the case of restarting one server out of four, the collection of profiles will stop for all. The new flag allows you to ignore such errors.